### PR TITLE
add Clipboard copy links

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,8 @@ Authors@R: c(
 	person("Martijn", "Tennekes", email = "mtennekes@gmail.com", role = c("aut", "cre")),
 	person("Achim", "Zeileis", email = "Achim.Zeileis@R-project.org", role = "ctb"),
 	person("Jakub", "Nowosad", email = "nowosad.jakub@gmail.com", role = "ctb"),
-	person("Robin", "Lovelace", email = "rob00x@gmail.com", role = "ctb")
+	person("Robin", "Lovelace", email = "rob00x@gmail.com", role = "ctb"),
+	person("Helgasoft", email = "contact@helgasoft.com", role = "ctb")
 	)
 Description: Color palettes for all people, including those with color vision deficiency. The color palettes are organized by type: categorical, sequential, diverging, and bivariate.
 Version: 0.1

--- a/R/c4a_show.R
+++ b/R/c4a_show.R
@@ -299,7 +299,8 @@ c4a_show = function(type = c("cat", "seq", "div"), n = NULL, cvd.sim = c("none",
 	extra = c("<style>", "table {", "\tborder-collapse: collapse;", "\tfont-size: 12px;",
 			  "\tborder-collapse: collapse;", "}", "", "td {", "\tborder-radius: 0px;",
 			  "\tborder: 1px solid white;", "\tborder-collapse: collapse;",
-			  "}", "", "th {", "\ttext-align: center;", "}", "", "</style>"
+			  "}", "", "th {", "\ttext-align: center;", "}", "", 
+			  "a:link {color: black;}", "</style>"
 	) # extra = readLines("build/extra.txt"); dput(extra)
 
 	k[1] = paste(c(extra,kl), collapse="\n")

--- a/R/c4a_show.R
+++ b/R/c4a_show.R
@@ -186,7 +186,20 @@ c4a_show = function(type = c("cat", "seq", "div"), n = NULL, cvd.sim = c("none",
 	}
 
 	e2 = cbind(e, me)
-
+	
+	if (show.ranking) {
+		# add hyperlinks to Ranking column for copying row colors to Clipboard
+		links <- c()
+		for (rw in 1:nrow(e2)) {
+			js.code <- "javascript:navigator.clipboard.writeText(`c("
+			for(cl in colNames) js.code <- paste0(js.code, "'",e2[rw,cl],"',")
+			js.code <- sub(",([^,]*)$", ")`)\\1", js.code)
+			links <- c(links, js.code)
+		}
+		e2[['Ranking']] = kableExtra::cell_spec(e2[['Ranking']], link=links, 
+			tooltip='click to copy palette to Clipboard')
+	}
+	
 	sim = switch(cvd.sim,
 				 none = function(x) x,
 				 deutan = colorspace::deutan,


### PR DESCRIPTION
 Great library, used it right away! 
 I used the Shiny app and needed only one palette though, so I copy/pasted the color codes from one row. Then I had to replace tabs with separators to finally get to a vector like **c('#E2E2E2', '#C5C5C5',...)**.
How about being able to just click on a certain row and have the color vector ready in the **Clipboard**?
That's the goal of this pull request code.
I chose column "Ranking" because it looked like a 'permanent' column with predictable content, and close to the colors too. Didn't want to clutter the beautiful design with extra column or buttons.
Command **c4a** of course is the _official way_ to get a palette from the library.  Code here is just an enhancement to the Shiny app.