### PR TITLE
fix pkgdown

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,4 @@
 url: https://mtennekes.github.io/cols4all/
 template:
   bootstrap: 5
-
+  math-rendering: mathjax

--- a/vignettes/paper.Rmd
+++ b/vignettes/paper.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Analysing and comparing color palettes with cols4all"
+title: "cols4all: analysing and comparing color palettes"
 output: 
   bookdown::html_vignette2:
 pkgdown:


### PR DESCRIPTION
Sorry! Should have been clearer. The math-rendering should have been done in `_pkgdown.yml`.

Local preview:
![image](https://github.com/user-attachments/assets/a59204d8-8b03-432c-a2ef-02765d38486c)
